### PR TITLE
towers can now take an input

### DIFF
--- a/Assets/Scenes/Gameplay Screen.meta
+++ b/Assets/Scenes/Gameplay Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6095e2960d810640943d067d1741f17
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Gameplay Screen.unity
+++ b/Assets/Scenes/Gameplay Screen.unity
@@ -1955,6 +1955,95 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 448782541}
   m_CullTransparentMesh: 0
+--- !u!1 &478136765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 478136766}
+  - component: {fileID: 478136769}
+  - component: {fileID: 478136768}
+  - component: {fileID: 478136767}
+  m_Layer: 5
+  m_Name: Drag and Drop Image (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &478136766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 478136765}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1551436319}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 125, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &478136767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 478136765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9de19b133e18ef540abd491d1a2839ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefab: {fileID: 289923724865494613, guid: edf2019c70479854a816ec5e7bdfbd8d, type: 3}
+--- !u!114 &478136768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 478136765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &478136769
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 478136765}
+  m_CullTransparentMesh: 0
 --- !u!1 &495345233
 GameObject:
   m_ObjectHideFlags: 0
@@ -2579,7 +2668,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9de19b133e18ef540abd491d1a2839ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugItem: {fileID: 0}
   prefab: {fileID: 5441440179506755017, guid: e27bcfa79fbd59c4fbdbf28b9afcb4e3, type: 3}
 --- !u!114 &662208634
 MonoBehaviour:
@@ -3917,8 +4005,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9de19b133e18ef540abd491d1a2839ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugItem: {fileID: 11400000, guid: 91829cbf5bd9012478d25238983f7682, type: 2}
-  prefab: {fileID: 3033235629050494089, guid: 4d85fc1d3e694444f8129412459fe17a, type: 3}
+  prefab: {fileID: 4531346496615889119, guid: 84cfd0fec5393fb49867111d3d8e1503, type: 3}
 --- !u!1 &1200527568
 GameObject:
   m_ObjectHideFlags: 0
@@ -5225,6 +5312,7 @@ RectTransform:
   m_Children:
   - {fileID: 1169422334}
   - {fileID: 662208632}
+  - {fileID: 478136766}
   m_Father: {fileID: 108916126}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6683,8 +6771,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0abb985b34002bd4186bcc904714b833, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sprite: {fileID: 1966678807}
-  projectileSpeed: 5
   playerPosition: {fileID: 1966678811}
   proj: {fileID: 3012422394887249208, guid: 31d642e53174953469546c2fc351b4b6, type: 3}
 --- !u!1 &1970966837

--- a/Assets/Scenes/Gameplay Screen/Main Camera Profile.asset
+++ b/Assets/Scenes/Gameplay Screen/Main Camera Profile.asset
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: Main Camera Profile
+  m_EditorClassIdentifier: 
+  components: []
+--- !u!114 &4527220781123262592
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d08ce26990eb1a4a9177b860541e702, type: 3}
+  m_Name: Exposure
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  mode:
+    m_OverrideState: 0
+    m_Value: 0
+  meteringMode:
+    m_OverrideState: 0
+    m_Value: 2
+  luminanceSource:
+    m_OverrideState: 0
+    m_Value: 1
+  fixedExposure:
+    m_OverrideState: 0
+    m_Value: 0
+  compensation:
+    m_OverrideState: 0
+    m_Value: 0
+  limitMin:
+    m_OverrideState: 0
+    m_Value: -10
+  limitMax:
+    m_OverrideState: 0
+    m_Value: 20
+  curveMap:
+    m_OverrideState: 0
+    m_Value:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: -10
+        value: -10
+        inSlope: 0
+        outSlope: 1
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 20
+        value: 20
+        inSlope: 1
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  adaptationMode:
+    m_OverrideState: 0
+    m_Value: 1
+  adaptationSpeedDarkToLight:
+    m_OverrideState: 0
+    m_Value: 3
+    min: 0.001
+  adaptationSpeedLightToDark:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.001

--- a/Assets/Scenes/Gameplay Screen/Main Camera Profile.asset.meta
+++ b/Assets/Scenes/Gameplay Screen/Main Camera Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3736476c956c9384dbd03401e30e6794
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/DayNightCycle.cs
+++ b/Assets/Scripts/DayNightCycle.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DayNightCycle : MonoBehaviour
+{
+    public float speed = 1;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        this.transform.Rotate(new Vector3(speed,0, 0));
+    }
+}

--- a/Assets/Scripts/DayNightCycle.cs.meta
+++ b/Assets/Scripts/DayNightCycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3283f3b0c2f7634396b64c1a2476c35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -50,7 +50,7 @@ namespace HordeSurvivalGame
             if (healthBarTimeLeft > 0)
             {
                 float percent = (float)remainingHealth / (float)maxHealth;
-                Debug.Log(percent);
+                //Debug.Log(percent);
                 healthBar.value = percent;
                 healthBar.gameObject.SetActive(true);
                 healthBarTimeLeft -= Time.deltaTime;
@@ -105,7 +105,6 @@ namespace HordeSurvivalGame
 
         public void Damage(int damageNumbers)
         {
-            Debug.Log("Enemy damaged!");
             remainingHealth -= damageNumbers;
             if (remainingHealth <=0)
             {

--- a/Assets/Scripts/Pathfinder/Pathfinding.cs
+++ b/Assets/Scripts/Pathfinder/Pathfinding.cs
@@ -45,78 +45,71 @@ namespace Pathfinder
 
         private void SearchAdjacentTiles(Tile startTile, Tile destinationTile, Tile CurrentTile)
         {
-            //Debug.Log("Calculating best adjacent tile from :" + CurrentTile.x + "," + CurrentTile.y);
-
-            // if a path is found
-            if (CurrentTile == destinationTile)
+            for(int i = 0; i < 5000;i++)
             {
-                DrawPath(CurrentTile, startTile);
-            }
-            else
-            {
-                CloseTile(CurrentTile);
-
-
-                
-                // for each neighbour of the current tile
-                for (int xOffset = -1; xOffset <= 1; xOffset++){
-                for (int yOffset = -1; yOffset <= 1; yOffset++)
+                // if a path is found
+                if (CurrentTile == destinationTile)
                 {
-                    if (!(xOffset == 0 && yOffset == 0)) // dont pathfind the tile you are already on
+                    DrawPath(CurrentTile, startTile);
+                    break;
+                }
+                else
+                {
+                    CloseTile(CurrentTile);
+
+
+
+                    // for each neighbour of the current tile
+                    for (int xOffset = -1; xOffset <= 1; xOffset++)
                     {
-                        Tile neighbour = Tile.tileMap[CurrentTile.x + xOffset, CurrentTile.y + yOffset];
-                        if (!closedTiles.Contains(neighbour))// dont pathfind a closed tile
+                        for (int yOffset = -1; yOffset <= 1; yOffset++)
                         {
-                            // if ther are errors here. move this if statement to encapsulate the definition of "neighnour"
-                            if (Tile.IsOnMap(CurrentTile.x + xOffset, CurrentTile.y + yOffset)) // check if tile is on the map (within bounds of array)
+                            if (!(xOffset == 0 && yOffset == 0)) // dont pathfind the tile you are already on
                             {
-                                if (neighbour.isWalkable)//  dont pathfind over tiles that aren't walkable
+                                Tile neighbour = Tile.tileMap[CurrentTile.x + xOffset, CurrentTile.y + yOffset];
+                                if (!closedTiles.Contains(neighbour))// dont pathfind a closed tile
                                 {
-                                    // only update the f cost if it is less than it was before
-                                    if ((neighbour.CheckFCost(startTile, destinationTile) < neighbour.fCost) || !OpenTiles.Contains(neighbour))
+                                    // if ther are errors here. move this if statement to encapsulate the definition of "neighnour"
+                                    if (Tile.IsOnMap(CurrentTile.x + xOffset, CurrentTile.y + yOffset)) // check if tile is on the map (within bounds of array)
                                     {
-                                        neighbour.UpdateValues(startTile, destinationTile, Tile.tileMap[CurrentTile.x, CurrentTile.y]);
-                                        OpenTile(Tile.tileMap[CurrentTile.x + xOffset, CurrentTile.y + yOffset]);
+                                        if (neighbour.isWalkable)//  dont pathfind over tiles that aren't walkable
+                                        {
+                                            // only update the f cost if it is less than it was before
+                                            if ((neighbour.CheckFCost(startTile, destinationTile) < neighbour.fCost) || !OpenTiles.Contains(neighbour))
+                                            {
+                                                neighbour.UpdateValues(startTile, destinationTile, Tile.tileMap[CurrentTile.x, CurrentTile.y]);
+                                                OpenTile(Tile.tileMap[CurrentTile.x + xOffset, CurrentTile.y + yOffset]);
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-                }
 
-                // search through all open tiles for the one with the lowest fCost
+                    // search through all open tiles for the one with the lowest fCost
 
-                Tile bestTile = new Tile();
-                float bestFCost = 99999.0f;
-                if(OpenTiles.Count > 0)
-                {
-                    foreach (Tile t in OpenTiles)
+                    Tile bestTile = new Tile();
+                    float bestFCost = 99999.0f;
+                    if (OpenTiles.Count > 0)
                     {
-                        if (t.fCost < bestFCost)
+                        foreach (Tile t in OpenTiles)
                         {
-                            bestTile = t;
-                            bestFCost = t.fCost;
+                            if (t.fCost < bestFCost)
+                            {
+                                bestTile = t;
+                                bestFCost = t.fCost;
+                            }
                         }
                     }
-                }
-                // if there are no open tiles left, the pathfinding cannot find a path
-                else
-                {
-                    Debug.LogError("Pathfinder: no path is possible");
-                    return;
-                }
+                    // if there are no open tiles left, the pathfinding cannot find a path
+                    else
+                    {
+                        Debug.LogError("Pathfinder: no path is possible");
+                        return;
+                    }
 
-                // this if statement is to stop infinite loops. this recursive funtion will call itself 1000 times before it fails; this stops unity crashing
-                if (count < 5000)
-                {
-                    count++;
-                    // run this function on the open tile with the lowest fCost
-                    SearchAdjacentTiles(startTile, destinationTile, bestTile);
-                }
-                else
-                {
-                    Debug.LogError("Pathfinder: failed");
+                    CurrentTile = bestTile;
                 }
             }
         }

--- a/Assets/Scripts/Pathfinder/Tile.cs
+++ b/Assets/Scripts/Pathfinder/Tile.cs
@@ -39,6 +39,7 @@ namespace Pathfinder.tiles
         public GameObject tileObject;
         public GameObject towerObject = null;
         public bool isWalkable = true;
+        public Vector3 vector;
 
         // attributes assigned per each entity pathfinding
         private float gCost = -1; // distance from the start point
@@ -54,6 +55,7 @@ namespace Pathfinder.tiles
             x = xCoOrd;
             y = yCoOrd;
             tileObject = tileGameObject;
+            vector = new Vector3(-x, 0, -y);
         }
         // used to turn a Tile into an OreTile
         public Tile(Tile t)
@@ -107,7 +109,8 @@ namespace Pathfinder.tiles
         }
         public static Vector3 TileToVector3(Tile t)
         {
-            return new Vector3(-t.x + 0.0f, 0, -t.y+ 0.0f);
+            return t.vector;
+            //return new Vector3(-t.x + 0.0f, 0, -t.y+ 0.0f);
         }
         // checks any indexers before they create out of bounds errors
         public static bool IsOnMap(int x, int y)

--- a/Assets/Scripts/TowerPlacement.cs
+++ b/Assets/Scripts/TowerPlacement.cs
@@ -11,7 +11,6 @@ namespace HordeSurvivalGame
 {
     public class TowerPlacement : MonoBehaviour, IDragHandler, IEndDragHandler, IBeginDragHandler
     {
-        public ItemSystem.Item debugItem;
         GameObject Tower;
         public GameObject prefab;
         bool readyToPlace = false;

--- a/Assets/Scripts/Towers/Mine.cs
+++ b/Assets/Scripts/Towers/Mine.cs
@@ -20,6 +20,7 @@ namespace Towers
         void Start()
         {
             // TODO: call TowerSetup() on parent
+            inv = new Inventory();
         }
 
         public void Setup()
@@ -51,6 +52,16 @@ namespace Towers
                     timeSinceLastDrop -= miningSpeed;
                     Drop();
                 }
+            }
+            //PrintInv();
+        }
+
+
+        private void PrintInv()
+        {
+            for (int i = 0; i < inv.items.Count; i++)
+            {
+                Debug.Log(inv.items[i].name + " : " + inv.quantity[i]);
             }
         }
 

--- a/Assets/Scripts/Towers/Turret.cs
+++ b/Assets/Scripts/Towers/Turret.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 using HordeSurvivalGame;
+using System;
+using ItemSystem;
 
 namespace Towers
 {
@@ -45,7 +47,7 @@ namespace Towers
         // Start is called before the first frame update
         void Start()
         {
-
+            inv = new Inventory();
         }
 
         // Update is called once per frame
@@ -60,6 +62,15 @@ namespace Towers
             else
             {
                 ShootAtEnemy();
+            }
+            PrintInv();
+        }
+
+        private void PrintInv()
+        {
+            for(int i = 0; i < inv.items.Count;i++)
+            {
+                Debug.Log( inv.items[i].name +" : "+ inv.quantity[i]);
             }
         }
 
@@ -97,7 +108,6 @@ namespace Towers
                     // if it has the tag "enemy", target that entity
                     if (colliderInRange.gameObject.tag == "Enemy")
                     {
-                        Debug.Log("found enemy");
                         targetEnemy = colliderInRange.gameObject.GetComponent<Enemy>();
                     }
                 }

--- a/Assets/prefabs/Mining Tower.prefab
+++ b/Assets/prefabs/Mining Tower.prefab
@@ -550,6 +550,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7947663774341142067}
+  - component: {fileID: 4888470929697938486}
+  - component: {fileID: -6478142491482797111}
   m_Layer: 0
   m_Name: Mining Tower
   m_TagString: Untagged
@@ -575,6 +577,34 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4888470929697938486
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4531346496615889119}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &-6478142491482797111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4531346496615889119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adedaecccdc5b894fb72a15280510305, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  x: 0
+  y: 0
+  recievableItem: {fileID: 0}
 --- !u!1 &5361833199856160500
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/prefabs/Turret.prefab
+++ b/Assets/prefabs/Turret.prefab
@@ -113,7 +113,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   x: 0
   y: 0
-  recievableItem: {fileID: 0}
+  recievableItem: {fileID: 11400000, guid: dc22b42ef0f48894bb2e1a02112d2a34, type: 2}
   head: {fileID: 634832989556087125}
   range: 10
   fireRate: 1


### PR DESCRIPTION
no more item duplication on conveyors (unless split - splits still duplicate)
turrets can now take an input |(as can all tower types
but the item filter for towers is not active yet

pathfinding changed to a for loop - no more recursion. this fixes the errors with stack overflows